### PR TITLE
Improve Circle CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,12 @@ build-filters: &build-filters
   branches:
     only: /.*/
 
+latest-filters: &latest-filters
+  tags:
+    ignore: /.*/
+  branches:
+    only: master
+
 deploy-filters: &deploy-filters
   tags:
     only: /.*/
@@ -40,21 +46,9 @@ jobs:
       - setup_remote_docker
       - checkout
       - run: make build
-        # - run:
-        #     name: make test-functional
-        #     command: |
-        #       python -m venv .venv
-        #       source .venv/bin/activate
-        #       pip install tox
-        #       make test-functional
       - run: *docker-login
       - run: make push-ci
-      # - run:
-      #     name: Push to Docker Hub
-      #     command: |
-      #       echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
-      #       make tag-latest
-      #       make push
+
   lint:
     docker:
       - image: circleci/buildpack-deps:bionic
@@ -87,6 +81,18 @@ jobs:
       - run: make pull-ci
       - run: make test-functional
 
+  push-latest:
+    docker:
+      - image: circleci/buildpack-deps:bionic
+    working_directory: ~/cloc.me
+    steps:
+      - setup_remote_docker
+      - checkout
+      - run: *docker-login
+      - run: make pull-ci
+      - run: make tag-latest
+      - run: make push-latest
+
 # ####################
 #
 # CircleCI Workflow
@@ -110,3 +116,10 @@ workflows:
           requires:
               - build
           filters: *build-filters
+      - push-latest:
+          requires:
+              - lint
+              - unit-test
+              - functional-test
+          filters: *latest-filters
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,16 @@ deploy-filters: &deploy-filters
 
 # ####################
 #
+# CircleCI steps
+#
+# ####################
+
+docker-login: &docker-login
+  name: Log into Docker Hub
+  command: echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+
+# ####################
+#
 # CircleCI 2.0 Jobs
 #
 # ####################
@@ -24,14 +34,12 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/buildpack-deps:bionic
     working_directory: ~/cloc.me
     steps:
       - setup_remote_docker
       - checkout
       - run: make build
-      - run: make test-lint
-      - run: make test-unit
         # - run:
         #     name: make test-functional
         #     command: |
@@ -39,12 +47,45 @@ jobs:
         #       source .venv/bin/activate
         #       pip install tox
         #       make test-functional
-      - run:
-          name: Push to Docker Hub
-          command: |
-            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
-            make tag-latest
-            make push
+      - run: *docker-login
+      - run: make push-ci
+      # - run:
+      #     name: Push to Docker Hub
+      #     command: |
+      #       echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+      #       make tag-latest
+      #       make push
+  lint:
+    docker:
+      - image: circleci/buildpack-deps:bionic
+    working_directory: ~/cloc.me
+    steps:
+      - setup_remote_docker
+      - checkout
+      - run: *docker-login
+      - run: make pull-ci
+      - run: make test-lint
+
+  unit-test:
+    docker:
+      - image: circleci/buildpack-deps:bionic
+    working_directory: ~/cloc.me
+    steps:
+      - setup_remote_docker
+      - checkout
+      - run: *docker-login
+      - run: make pull-ci
+      - run: make test-unit
+
+  functional-test:
+    machine:
+        image: circleci/classic:latest
+    working_directory: ~/cloc.me
+    steps:
+      - checkout
+      - run: *docker-login
+      - run: make pull-ci
+      - run: make test-functional
 
 # ####################
 #
@@ -56,4 +97,16 @@ workflows:
   cloc-me-workflow:
     jobs:
       - build:
+          filters: *build-filters
+      - lint:
+          requires:
+              - build
+          filters: *build-filters
+      - unit-test:
+          requires:
+              - build
+          filters: *build-filters
+      - functional-test:
+          requires:
+              - build
           filters: *build-filters

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test-functional:
 tag-latest:
 	docker tag $(DOCKER_REPO):local $(DOCKER_REPO):latest
 
-push:
+push-latest:
 	docker push $(DOCKER_REPO):latest
 
 push-ci:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 DOCKER_REPO := clocme/clocme
+DOCKER_REPO_CI := clocme/clocme-ci
+GIT_HASH = $(shell git rev-parse --short HEAD)
 
 build:
 	docker build -t $(DOCKER_REPO):local .
@@ -18,14 +20,28 @@ test-unit:
 		-e unit
 
 test-functional:
-	# docker run --rm -it \
-	# 	--entrypoint tox \
-	# 	$(DOCKER_REPO):local \
-	# 	-e functional
-	IMAGE_NAME=$(DOCKER_REPO):local tox -e functional
+	docker run --rm -it \
+		-w /clocme \
+		-v `pwd`:/clocme \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-e IMAGE_NAME=$(DOCKER_REPO):local \
+		python:alpine \
+		ash -c ' \
+			set -e; \
+			pip install tox; \
+			tox -e functional \
+		'
 
 tag-latest:
 	docker tag $(DOCKER_REPO):local $(DOCKER_REPO):latest
 
 push:
 	docker push $(DOCKER_REPO):latest
+
+push-ci:
+	docker tag $(DOCKER_REPO):local $(DOCKER_REPO_CI):$(GIT_HASH)
+	docker push $(DOCKER_REPO_CI):$(GIT_HASH)
+
+pull-ci:
+	docker pull $(DOCKER_REPO_CI):$(GIT_HASH)
+	docker tag $(DOCKER_REPO_CI):$(GIT_HASH) $(DOCKER_REPO):local


### PR DESCRIPTION
- Split build, lint, and test jobs
- Integrate `clocme/clocme-ci` Docker Hub repo for CI building/testing
- Add `:latest` tag push job to workflow